### PR TITLE
Add Gitpod Automations to catalogue

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1208,6 +1208,17 @@
       "url": "https://json.schemastore.org/github-workflow-template-properties.json"
     },
     {
+      "name": "Gitpod Automation",
+      "description": "Json schema for configuration properties of Gitpod Automations",
+      "fileMatch": [
+        "automations.json",
+        "automations.yaml",
+        "automations.yml",
+        "automation.yaml"
+      ],
+      "url": "https://app.gitpod.io/jsonschema/v1/automations_file.jsonschema.json"
+    },
+    {
       "name": "gitlab-ci",
       "description": "JSON schema for configuring Gitlab CI",
       "fileMatch": [


### PR DESCRIPTION
Adds Gitpod Automations schema to the catalogue

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
